### PR TITLE
fix every time TRUE for empty $_GET

### DIFF
--- a/src/SeatGeek/Sixpack/Session/Base.php
+++ b/src/SeatGeek/Sixpack/Session/Base.php
@@ -83,7 +83,7 @@ class Base
     public function isForced($experiment)
     {
         $forceKey = "sixpack-force-" . $experiment;
-        if (in_array($forceKey, array_keys($_GET))) {
+        if (in_array($forceKey, array_keys($_GET), true)) {
             return true;
         }
         return false;


### PR DESCRIPTION
from this https://stackoverflow.com/questions/25496212/in-array-function-returns-true-when-passing-empty-array